### PR TITLE
Correção tpCdsOrigem nos xml's de exemplo

### DIFF
--- a/xml-exemplo/Atendimento_Domiciliar.esus.xml
+++ b/xml-exemplo/Atendimento_Domiciliar.esus.xml
@@ -8,7 +8,7 @@
 	<numLote>1</numLote>
 	<ns4:fichaAtendimentoDomiciliarMasterTransport>
 		<uuidFicha>5444429-dee8f6ef-9f0a-42e3-8d99-7231564694e1</uuidFicha>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<headerTransport>
 			<lotacaoFormPrincipal>
 				<profissionalCNS>700609923387762</profissionalCNS>

--- a/xml-exemplo/Atendimento_Individual.esus.xml
+++ b/xml-exemplo/Atendimento_Individual.esus.xml
@@ -91,7 +91,7 @@
 			<racionalidadeSaude>4</racionalidadeSaude>
 			<perimetroCefalico>56.0</perimetroCefalico>
 		</atendimentosIndividuais>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<uuidFicha>5444429-e3da23da-bf5c-48b4-9982-0e85bf46483e</uuidFicha>
 	</ns4:fichaAtendimentoIndividualMasterTransport>
 	<ns2:remetente>

--- a/xml-exemplo/Atendimento_Odotonlogico.esus.xml
+++ b/xml-exemplo/Atendimento_Odotonlogico.esus.xml
@@ -7,7 +7,7 @@
 	<numLote>1</numLote>
 	<ns4:fichaAtendimentoOdontologicoMasterTransport>
 		<uuidFicha>5444429-0196af04-26d9-435e-867f-e7c0a71599ce</uuidFicha>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<atendimentosOdontologicos>
 			<numProntuario>34567</numProntuario>
 			<cnsCidadao>279573698530018</cnsCidadao>

--- a/xml-exemplo/Atividade_Coletiva.esus.xml
+++ b/xml-exemplo/Atividade_Coletiva.esus.xml
@@ -21,7 +21,7 @@
 			<abandonouGrupo>false</abandonouGrupo>
 			<sexo>1</sexo>
 		</participantes>
-		<tbCdsOrigem>1</tbCdsOrigem>
+		<tbCdsOrigem>3</tbCdsOrigem>
 		<turno>2</turno>
 		<pseEducacao>false</pseEducacao>
 		<pseSaude>false</pseSaude>

--- a/xml-exemplo/Atividade_Coletiva_AvaliacaoProcedimentoColetivo.esus.xml
+++ b/xml-exemplo/Atividade_Coletiva_AvaliacaoProcedimentoColetivo.esus.xml
@@ -29,7 +29,7 @@
 			<abandonouGrupo>true</abandonouGrupo>
 			<sexo>0</sexo>
 		</participantes>
-		<tbCdsOrigem>1</tbCdsOrigem>
+		<tbCdsOrigem>3</tbCdsOrigem>
 		<cnesLocalAtividade>6364403</cnesLocalAtividade>
 		<procedimento>0101020023</procedimento>
 		<turno>1</turno>

--- a/xml-exemplo/Atividade_Coletiva_EducacaoSaude.esus.xml
+++ b/xml-exemplo/Atividade_Coletiva_EducacaoSaude.esus.xml
@@ -30,7 +30,7 @@
 			<altura>150.0</altura>
 			<sexo>1</sexo>
 		</participantes>
-		<tbCdsOrigem>1</tbCdsOrigem>
+		<tbCdsOrigem>3</tbCdsOrigem>
 		<turno>1</turno>
 		<pseEducacao>true</pseEducacao>
 		<pseSaude>true</pseSaude>

--- a/xml-exemplo/Atividade_Coletiva_Reuniao.esus.xml
+++ b/xml-exemplo/Atividade_Coletiva_Reuniao.esus.xml
@@ -25,7 +25,7 @@
 			<altura>100.0</altura>
 			<sexo>0</sexo>
 		</participantes>
-		<tbCdsOrigem>1</tbCdsOrigem>
+		<tbCdsOrigem>3</tbCdsOrigem>
 		<turno>3</turno>
 		<pseEducacao>false</pseEducacao>
 		<pseSaude>false</pseSaude>

--- a/xml-exemplo/Avaliacao_Elegibilidade_Elegivel.esus.xml
+++ b/xml-exemplo/Avaliacao_Elegibilidade_Elegivel.esus.xml
@@ -18,7 +18,7 @@
 			<codigoIbgeMunicipio>4205407</codigoIbgeMunicipio>
 		</headerTransport>
 		<uuidFicha>5444428-2bcb85ec-212f-47fc-88a7-baae0d432926</uuidFicha>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<turno>1</turno>
 		<cnsCidadao>898050047989752</cnsCidadao>
 		<dataNascimentoCidadao>813765600000</dataNascimentoCidadao>

--- a/xml-exemplo/Avaliacao_Elegibilidade_Inelegivel.esus.xml
+++ b/xml-exemplo/Avaliacao_Elegibilidade_Inelegivel.esus.xml
@@ -18,7 +18,7 @@
 			<codigoIbgeMunicipio>4205407</codigoIbgeMunicipio>
 		</headerTransport>
 		<uuidFicha>5444428-52b23223-774a-4158-8457-09bbb8ec4fc7</uuidFicha>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<turno>2</turno>
 		<cnsCidadao>898050047989752</cnsCidadao>
 		<dataNascimentoCidadao>1046700000000</dataNascimentoCidadao>

--- a/xml-exemplo/Cadastro_Domiciliar.esus.xml
+++ b/xml-exemplo/Cadastro_Domiciliar.esus.xml
@@ -60,7 +60,7 @@
 		<quantosAnimaisNoDomicilio>3</quantosAnimaisNoDomicilio>
 		<stAnimaisNoDomicilio>true</stAnimaisNoDomicilio>
 		<statusTermoRecusa>false</statusTermoRecusa>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<uuid>5444429-5f295fe4-ba40-4894-a7d0-d474798126b0</uuid>
 		<uuidFichaOriginadora>5444429-5f295fe4-ba40-4894-a7d0-d474798126b0</uuidFichaOriginadora>
 		<tipoDeImovel>1</tipoDeImovel>

--- a/xml-exemplo/Cadastro_Domiciliar_OutroImovel.esus.xml
+++ b/xml-exemplo/Cadastro_Domiciliar_OutroImovel.esus.xml
@@ -32,7 +32,7 @@
 		</enderecoLocalPermanencia>
 		<fichaAtualizada>false</fichaAtualizada>
 		<statusTermoRecusa>false</statusTermoRecusa>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<uuid>5444429-e5df6b42-313d-4efe-add1-24cdc368cda9</uuid>
 		<uuidFichaOriginadora>5444429-e5df6b42-313d-4efe-add1-24cdc368cda9</uuidFichaOriginadora>
 		<tipoDeImovel>7</tipoDeImovel>

--- a/xml-exemplo/Cadastro_Domiciliar_Recusa.esus.xml
+++ b/xml-exemplo/Cadastro_Domiciliar_Recusa.esus.xml
@@ -26,7 +26,7 @@
 		</enderecoLocalPermanencia>
 		<fichaAtualizada>false</fichaAtualizada>
 		<statusTermoRecusa>true</statusTermoRecusa>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<uuid>5444429-eb20ac03-0bce-489b-8eb1-ca4a0ea1e42a</uuid>
 		<uuidFichaOriginadora>5444429-eb20ac03-0bce-489b-8eb1-ca4a0ea1e42a</uuidFichaOriginadora>
 		<tipoDeImovel>1</tipoDeImovel>

--- a/xml-exemplo/Cadastro_Individual.esus.xml
+++ b/xml-exemplo/Cadastro_Individual.esus.xml
@@ -93,7 +93,7 @@
 		</informacoesSocioDemograficas>
 		<saidaCidadaoCadastro />
 		<statusTermoRecusaCadastroIndividualAtencaoBasica>false</statusTermoRecusaCadastroIndividualAtencaoBasica>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<uuid>5444429-0fee3dd1-c44c-417c-bc35-984326843cd7</uuid>
 		<uuidFichaOriginadora>5444429-0fee3dd1-c44c-417c-bc35-984326843cd7</uuidFichaOriginadora>
 		<headerTransport>

--- a/xml-exemplo/Cadastro_Individual_Recusa.esus.xml
+++ b/xml-exemplo/Cadastro_Individual_Recusa.esus.xml
@@ -32,7 +32,7 @@
 		<informacoesSocioDemograficas />
 		<saidaCidadaoCadastro />
 		<statusTermoRecusaCadastroIndividualAtencaoBasica>true</statusTermoRecusaCadastroIndividualAtencaoBasica>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<uuid>5444429-9b109465-2b83-4c9e-89dd-aa6223f24a95</uuid>
 		<uuidFichaOriginadora>5444429-9b109465-2b83-4c9e-89dd-aa6223f24a95</uuidFichaOriginadora>
 		<headerTransport>

--- a/xml-exemplo/Complementar_Zika_Microcefalia.esus.xml
+++ b/xml-exemplo/Complementar_Zika_Microcefalia.esus.xml
@@ -16,7 +16,7 @@
 			<codigoIbgeMunicipio>4205407</codigoIbgeMunicipio>
 		</headerTransport>
 		<uuidFicha>5444429-5235eb5f-6fab-48f2-be51-1c2e3982493d</uuidFicha>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<turno>1</turno>
 		<cnsCidadao>898050047989752</cnsCidadao>
 		<cnsResponsavelFamiliar>100291426250007</cnsResponsavelFamiliar>

--- a/xml-exemplo/Consumo_Alimentar_MaisDoisAnos.esus.xml
+++ b/xml-exemplo/Consumo_Alimentar_MaisDoisAnos.esus.xml
@@ -59,7 +59,7 @@
 			<respostaUnicaEscolha>NAO_SABE</respostaUnicaEscolha>
 		</perguntasQuestionarioCriancasComMaisDoisAnos>
 		<uuidFicha>5444429-8134c3ff-25ce-4900-9ade-7d8ef110e243</uuidFicha>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 	</ns4:fichaConsumoAlimentarTransport>
 	<ns2:remetente>
 		<contraChave>TREINAMENTO</contraChave>

--- a/xml-exemplo/Consumo_Alimentar_Menos6Meses.esus.xml
+++ b/xml-exemplo/Consumo_Alimentar_Menos6Meses.esus.xml
@@ -57,7 +57,7 @@
 			<respostaUnicaEscolha>NAO</respostaUnicaEscolha>
 		</perguntasQuestionarioCriancasMenoresSeisMeses>
 		<uuidFicha>5444429-61b3860b-29f2-44bc-ad6e-a42e06d73c99</uuidFicha>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 	</ns4:fichaConsumoAlimentarTransport>
 	<ns2:remetente>
 		<contraChave>TREINAMENTO</contraChave>

--- a/xml-exemplo/Consumo_Alimentar_SeisA23Meses.esus.xml
+++ b/xml-exemplo/Consumo_Alimentar_SeisA23Meses.esus.xml
@@ -99,7 +99,7 @@
 			<respostaUnicaEscolha>SIM</respostaUnicaEscolha>
 		</perguntasQuestionarioCriancasDeSeisVinteTresMeses>
 		<uuidFicha>5444429-6f1a9651-37bd-4639-bba9-ea41b52053b0</uuidFicha>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 	</ns4:fichaConsumoAlimentarTransport>
 	<ns2:remetente>
 		<contraChave>TREINAMENTO</contraChave>

--- a/xml-exemplo/Procedimentos.esus.xml
+++ b/xml-exemplo/Procedimentos.esus.xml
@@ -33,7 +33,7 @@
 			<outrosSiaProcedimentos>0101010010</outrosSiaProcedimentos>
 		</atendProcedimentos>
 		<uuidFicha>5444429-0fae865e-124b-411d-a5ab-8c4c23966046</uuidFicha>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<numTotalAfericaoPa>4</numTotalAfericaoPa>
 		<numTotalAfericaoTemperatura>3</numTotalAfericaoTemperatura>
 		<numTotalCurativoSimples>2</numTotalCurativoSimples>

--- a/xml-exemplo/Vacinacao.esus.xml
+++ b/xml-exemplo/Vacinacao.esus.xml
@@ -14,7 +14,7 @@
 			<codigoIbgeMunicipio>4205407</codigoIbgeMunicipio>
 		</headerTransport>
 		<uuidFicha>5444429-9de1d63d-f392-4f30-a14f-893418c29004</uuidFicha>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<vacinacoes>
 			<turno>1</turno>
 			<numProntuario>456</numProntuario>

--- a/xml-exemplo/Visita_Domiciliar.esus.xml
+++ b/xml-exemplo/Visita_Domiciliar.esus.xml
@@ -7,7 +7,7 @@
 	<numLote>1</numLote>
 	<ns4:fichaVisitaDomiciliarMasterTransport>
 		<uuidFicha>5444429-361e4bfa-d4cf-4a1c-adb8-5cb266c8f1e1</uuidFicha>
-		<tpCdsOrigem>1</tpCdsOrigem>
+		<tpCdsOrigem>3</tpCdsOrigem>
 		<headerTransport>
 			<profissionalCNS>700609923387762</profissionalCNS>
 			<cboCodigo_2002>515105</cboCodigo_2002>


### PR DESCRIPTION
Trocado tpCdsOrigem de CDS_ORIGEM_TODAS para CDS_ORIGEM_EXTERNO, conforme documentação https://doc.esusab.ufsc.br/3.1/ledi/documentacao/estrutura_arquivos/dicionario-fci.html (Regras: Utilizar valor 3 (sistemas terceiros)).